### PR TITLE
공통 예외 도입 및 보안 설정

### DIFF
--- a/src/main/java/university/likelion/wmt/common/cors/CorsConfig.java
+++ b/src/main/java/university/likelion/wmt/common/cors/CorsConfig.java
@@ -1,0 +1,39 @@
+package university.likelion.wmt.common.cors;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class CorsConfig {
+    @Bean
+    public SecurityFilterChain corsSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+            .build();
+    }
+
+    private CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(
+            List.of("http://localhost:3000", "http://localhost:5173", "http://localhost:8080"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setMaxAge(3600L);
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/university/likelion/wmt/common/exception/BusinessException.java
+++ b/src/main/java/university/likelion/wmt/common/exception/BusinessException.java
@@ -1,0 +1,28 @@
+package university.likelion.wmt.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return errorCode.getHttpStatus();
+    }
+
+    public int getCode() {
+        return errorCode.getCode();
+    }
+
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+
+    public String getDocumentationUri() {
+        return errorCode.getDocumentationUri();
+    }
+}

--- a/src/main/java/university/likelion/wmt/common/exception/CommonErrorCode.java
+++ b/src/main/java/university/likelion/wmt/common/exception/CommonErrorCode.java
@@ -1,0 +1,27 @@
+package university.likelion.wmt.common.exception;
+
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public enum CommonErrorCode implements ErrorCode {
+    UNEXPECTED_SERVER_ERROR(INTERNAL_SERVER_ERROR, 10000001, "예상치 못한 서버 오류가 발생했습니다.", null),
+    INVALID_ENDPOINT(NOT_FOUND, 10000002, "잘못된 API 엔드포인트 URI로 요청했습니다.", null),
+    INVALID_HTTP_METHOD(METHOD_NOT_ALLOWED, 10000003, "잘못된 HTTP 메서드로 요청했습니다.", null),
+    INVALID_REQUEST_BODY(BAD_REQUEST, 10000004, "잘못된 HTTP 요청 바디로 요청했습니다.", null);
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+    private final String documentationUri;
+
+    CommonErrorCode(HttpStatus httpStatus, int code, String message, String documentationUri) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+        this.documentationUri = documentationUri;
+    }
+}

--- a/src/main/java/university/likelion/wmt/common/exception/ErrorCode.java
+++ b/src/main/java/university/likelion/wmt/common/exception/ErrorCode.java
@@ -1,0 +1,13 @@
+package university.likelion.wmt.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+
+    int getCode();
+
+    String getMessage();
+
+    String getDocumentationUri();
+}

--- a/src/main/java/university/likelion/wmt/common/exception/ExceptionHandlerFilter.java
+++ b/src/main/java/university/likelion/wmt/common/exception/ExceptionHandlerFilter.java
@@ -1,0 +1,32 @@
+package university.likelion.wmt.common.exception;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (Exception ex) {
+            handlerExceptionResolver.resolveException(request, response, null, ex);
+        }
+    }
+}

--- a/src/main/java/university/likelion/wmt/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/university/likelion/wmt/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,92 @@
+package university.likelion.wmt.common.exception;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(BusinessException.class)
+    public ProblemDetail handleBusinessException(final BusinessException ex) {
+        log.warn("비즈니스 로직 수행 중 오류가 발생했습니다: {}", ex.getCode());
+
+        ProblemDetail detail = ProblemDetail.forStatus(ex.getHttpStatus());
+        if (!Objects.isNull(ex.getDocumentationUri())) {
+            detail.setType(URI.create(ex.getDocumentationUri()));
+        }
+        detail.setDetail(ex.getMessage());
+        detail.setProperty("code", ex.getCode());
+        detail.setProperty("timestamp", Instant.now());
+
+        return detail;
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ProblemDetail handleMethodNotSupportedException(final HttpRequestMethodNotSupportedException ex) {
+        ProblemDetail detail = ProblemDetail.forStatus(CommonErrorCode.INVALID_HTTP_METHOD.getHttpStatus());
+        detail.setDetail(CommonErrorCode.INVALID_ENDPOINT.getMessage());
+        detail.setProperty("timestamp", Instant.now());
+
+        return detail;
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ProblemDetail handleNotFoundException(final NoResourceFoundException ex) {
+        ProblemDetail detail = ProblemDetail.forStatus(CommonErrorCode.INVALID_ENDPOINT.getHttpStatus());
+        detail.setDetail(CommonErrorCode.INVALID_ENDPOINT.getMessage());
+        detail.setProperty("timestamp", Instant.now());
+
+        return detail;
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleMethodArgumentNotValidException(final MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new HashMap<>();
+        ex.getBindingResult().getAllErrors().forEach(error -> {
+            String fieldName = ((FieldError)error).getField();
+            String errorMessage = error.getDefaultMessage();
+            errors.put(fieldName, errorMessage);
+        });
+
+        ProblemDetail detail = ProblemDetail.forStatus(CommonErrorCode.INVALID_REQUEST_BODY.getHttpStatus());
+        detail.setDetail(CommonErrorCode.INVALID_REQUEST_BODY.getMessage());
+        detail.setProperty("errors", errors);
+        detail.setProperty("timestamp", Instant.now());
+
+        return detail;
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ProblemDetail handleHttpMessageNotReadableException(final HttpMessageNotReadableException ex) {
+        ProblemDetail detail = ProblemDetail.forStatus(CommonErrorCode.INVALID_REQUEST_BODY.getHttpStatus());
+        detail.setDetail(CommonErrorCode.INVALID_REQUEST_BODY.getMessage());
+        detail.setProperty("timestamp", Instant.now());
+
+        return detail;
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ProblemDetail handleUnexpectedException(final Exception ex) {
+        log.error("알 수 없는 오류가 발생했습니다: {}", ex.getMessage());
+
+        ProblemDetail detail = ProblemDetail.forStatus(CommonErrorCode.UNEXPECTED_SERVER_ERROR.getHttpStatus());
+        detail.setDetail(CommonErrorCode.UNEXPECTED_SERVER_ERROR.getMessage());
+        detail.setProperty("timestamp", Instant.now());
+
+        return detail;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/user/config/AuthConfig.java
+++ b/src/main/java/university/likelion/wmt/domain/user/config/AuthConfig.java
@@ -1,0 +1,43 @@
+package university.likelion.wmt.domain.user.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.common.exception.ExceptionHandlerFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class AuthConfig {
+    private final ExceptionHandlerFilter exceptionHandlerFilter;
+
+    @Bean
+    public SecurityFilterChain authSecurityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(session ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .anonymous(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .rememberMe(AbstractHttpConfigurer::disable)
+            .logout(AbstractHttpConfigurer::disable)
+
+            .addFilterBefore(exceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class)
+
+            .authorizeHttpRequests(req -> req
+                .anyRequest().permitAll())
+
+            .build();
+    }
+}


### PR DESCRIPTION
## 🚩 작업 요약

**1️⃣ 공통 예외 도입**
- 도메인 및 애플리케이션에서 사용할 공통 예외를 추가합니다.

**2️⃣ Spring MVC 계층 전역 예외 처리**
- `GlobalExceptionHandler`로 여러 예외를 클라이언트에게 반환합니다.
  - `BusinessException` 예외 발생 시 비즈니스 로직 예외와 관련한 내용을 반환합니다.
  - `MethodArgumentNotValidException` 예외 발생 시 검증 관련 내용을 반환합니다.
- `ExceptionHandlerFilter`를 추가하여 필터 상에서 발생하는 예외를 `HandlerExceptionResolver`로 위임합니다.

**4️⃣ 인증/보안 기본 설정**
- `AuthConfig`를 추가하여 인증/인가 없이 API를 호출할 수 있도록 합니다.

**5️⃣ CORS 설정**
- `CorsConfig`를 추가하여  `http://localhost:3000, :5173, :8080`에서 `GET, POST, PUT, PATCH, DELETE, OPTIONS` 메서드로 호출을 허용합니다.

## 📋 요구 사항
- 오류 코드에 대한 정의가 필요합니다.