### PR TITLE
이미지 도메인 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,59 +1,62 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.4'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.4'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'university.likelion'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	// Spring Web
-	implementation('org.springframework.boot:spring-boot-starter-web') {
-		exclude module: 'spring-boot-starter-tomcat'
-	}
-	// Undertow
-	implementation 'org.springframework.boot:spring-boot-starter-undertow'
+    // Spring Web
+    implementation('org.springframework.boot:spring-boot-starter-web') {
+        exclude module: 'spring-boot-starter-tomcat'
+    }
+    // Undertow
+    implementation 'org.springframework.boot:spring-boot-starter-undertow'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.apache.tika:tika-core:3.2.1'
 
-	// Spring Security
-	implementation 'org.springframework.boot:spring-boot-starter-security'
+    // Spring Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	// Spring Data JPA, QueryDSL
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'io.github.openfeign.querydsl:querydsl-core:6.12'
-	implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.12'
-	annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.12:jpa'
+    // Spring Data JPA, QueryDSL
+    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.10.1'
+    implementation 'io.github.openfeign.querydsl:querydsl-core:6.12'
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.12'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.12:jpa'
 
-	// Lombok
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
 
-	// Test
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'com.h2database:h2'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'com.h2database:h2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/university/likelion/wmt/WmtApplication.java
+++ b/src/main/java/university/likelion/wmt/WmtApplication.java
@@ -2,8 +2,12 @@ package university.likelion.wmt;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@ConfigurationPropertiesScan
 public class WmtApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/university/likelion/wmt/common/auth/AuthConfig.java
+++ b/src/main/java/university/likelion/wmt/common/auth/AuthConfig.java
@@ -1,4 +1,4 @@
-package university.likelion.wmt.domain.user.config;
+package university.likelion.wmt.common.auth;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,6 +12,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 import lombok.RequiredArgsConstructor;
 
+import university.likelion.wmt.common.cors.CorsConfig;
 import university.likelion.wmt.common.exception.ExceptionHandlerFilter;
 
 @Configuration
@@ -32,6 +33,9 @@ public class AuthConfig {
             .formLogin(AbstractHttpConfigurer::disable)
             .rememberMe(AbstractHttpConfigurer::disable)
             .logout(AbstractHttpConfigurer::disable)
+
+            .cors(cors -> cors
+                .configurationSource(CorsConfig.corsConfigurationSource()))
 
             .addFilterBefore(exceptionHandlerFilter, UsernamePasswordAuthenticationFilter.class)
 

--- a/src/main/java/university/likelion/wmt/common/cors/CorsConfig.java
+++ b/src/main/java/university/likelion/wmt/common/cors/CorsConfig.java
@@ -2,27 +2,15 @@ package university.likelion.wmt.common.cors;
 
 import java.util.List;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import lombok.RequiredArgsConstructor;
 
-@Configuration
 @RequiredArgsConstructor
 public class CorsConfig {
-    @Bean
-    public SecurityFilterChain corsSecurityFilterChain(HttpSecurity http) throws Exception {
-        return http
-            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-            .build();
-    }
-
-    private CorsConfigurationSource corsConfigurationSource() {
+    public static CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(
             List.of("http://localhost:3000", "http://localhost:5173", "http://localhost:8080"));

--- a/src/main/java/university/likelion/wmt/domain/dto/response/ImageResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/dto/response/ImageResponse.java
@@ -1,0 +1,6 @@
+package university.likelion.wmt.domain.dto.response;
+
+public record ImageResponse(
+    String url
+) {
+}

--- a/src/main/java/university/likelion/wmt/domain/dto/response/ImageResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/dto/response/ImageResponse.java
@@ -1,6 +1,0 @@
-package university.likelion.wmt.domain.dto.response;
-
-public record ImageResponse(
-    String url
-) {
-}

--- a/src/main/java/university/likelion/wmt/domain/image/controller/ImageController.java
+++ b/src/main/java/university/likelion/wmt/domain/image/controller/ImageController.java
@@ -1,0 +1,33 @@
+package university.likelion.wmt.domain.image.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.dto.response.ImageResponse;
+import university.likelion.wmt.domain.image.service.ImageService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/images")
+public class ImageController {
+    private final ImageService imageService;
+
+    @PostMapping("/upload")
+    public ResponseEntity<ImageResponse> upload(@RequestPart("file") MultipartFile file) {
+        return ResponseEntity.ok(imageService.upload(file));
+    }
+
+    @DeleteMapping("/{imageId}")
+    public ResponseEntity<Void> delete(@PathVariable("imageId") Long imageId) {
+        imageService.delete(imageId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/image/controller/ImageController.java
+++ b/src/main/java/university/likelion/wmt/domain/image/controller/ImageController.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
-import university.likelion.wmt.domain.dto.response.ImageResponse;
+import university.likelion.wmt.domain.image.dto.response.ImageResponse;
 import university.likelion.wmt.domain.image.service.ImageService;
 
 @RestController

--- a/src/main/java/university/likelion/wmt/domain/image/dto/response/ImageResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/image/dto/response/ImageResponse.java
@@ -1,0 +1,6 @@
+package university.likelion.wmt.domain.image.dto.response;
+
+public record ImageResponse(
+    String url
+) {
+}

--- a/src/main/java/university/likelion/wmt/domain/image/entity/Image.java
+++ b/src/main/java/university/likelion/wmt/domain/image/entity/Image.java
@@ -34,9 +34,9 @@ public class Image {
     @Column(nullable = false)
     private Long fileSize;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 128)
     private String contentType;
-    
+
     private Long refId;
 
     @Column(nullable = false)

--- a/src/main/java/university/likelion/wmt/domain/image/entity/Image.java
+++ b/src/main/java/university/likelion/wmt/domain/image/entity/Image.java
@@ -1,0 +1,52 @@
+package university.likelion.wmt.domain.image.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+
+@Entity
+@Table(name = "images")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class Image {
+    @Id
+    @Tsid
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 36)
+    private String cfName;
+
+    @Column(nullable = false)
+    private Long fileSize;
+
+    @Column(nullable = false)
+    private String contentType;
+    
+    private Long refId;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public Image(String cfName, Long fileSize, String contentType) {
+        this.cfName = cfName;
+        this.fileSize = fileSize;
+        this.contentType = contentType;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/image/exception/ImageErrorCode.java
+++ b/src/main/java/university/likelion/wmt/domain/image/exception/ImageErrorCode.java
@@ -1,0 +1,26 @@
+package university.likelion.wmt.domain.image.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+import university.likelion.wmt.common.exception.ErrorCode;
+
+@Getter
+public enum ImageErrorCode implements ErrorCode {
+    IMAGE_FILE_IO_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 47300001, "파일을 읽던 중 오류가 발생했습니다.", null),
+    IMAGE_MIME_NOT_ALLOWED(HttpStatus.UNSUPPORTED_MEDIA_TYPE, 47300002, "업로드할 수 없는 파일 형식입니다.", null),
+    CLOUDFLARE_IMAGES_UPLOAD_FAILED(HttpStatus.BAD_GATEWAY, 47300003, "파일 서버와 통신에 실패했습니다.", null);
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+    private final String documentationUri;
+
+    ImageErrorCode(HttpStatus httpStatus, int code, String message, String documentationUri) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+        this.documentationUri = documentationUri;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/image/exception/ImageException.java
+++ b/src/main/java/university/likelion/wmt/domain/image/exception/ImageException.java
@@ -1,0 +1,10 @@
+package university.likelion.wmt.domain.image.exception;
+
+import university.likelion.wmt.common.exception.BusinessException;
+import university.likelion.wmt.common.exception.ErrorCode;
+
+public class ImageException extends BusinessException {
+    public ImageException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/image/implement/ImageValidator.java
+++ b/src/main/java/university/likelion/wmt/domain/image/implement/ImageValidator.java
@@ -1,0 +1,39 @@
+package university.likelion.wmt.domain.image.implement;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.apache.tika.Tika;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import university.likelion.wmt.domain.image.exception.ImageErrorCode;
+import university.likelion.wmt.domain.image.exception.ImageException;
+import university.likelion.wmt.domain.image.property.ImageProperties;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageValidator {
+    private final ImageProperties properties;
+    private static final Tika tika = new Tika();
+
+    public void validateAllowedMime(MultipartFile file) {
+        // 파일 확장자 기반이 아닌 실제 파일의 MIME를 파악
+        String mimeFromContent = null;
+        try {
+            mimeFromContent = tika.detect(file.getInputStream());
+        } catch (IOException ignored) {
+            throw new ImageException(ImageErrorCode.IMAGE_FILE_IO_ERROR);
+        }
+
+        // 파일의 MIME가 허용된 MIME인지 확인하여 아니라면 예외를 발생시킴
+        String mime = mimeFromContent;
+        if (properties.getAllowedMime().stream().noneMatch(allowed -> Objects.equals(allowed, mime))) {
+            throw new ImageException(ImageErrorCode.IMAGE_MIME_NOT_ALLOWED);
+        }
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/image/implement/ImageWriter.java
+++ b/src/main/java/university/likelion/wmt/domain/image/implement/ImageWriter.java
@@ -19,8 +19,8 @@ import university.likelion.wmt.domain.image.service.CloudflareImagesClient;
 @Component
 @RequiredArgsConstructor
 public class ImageWriter {
-    private static String IMAGE_BASE_URI = "https://imagedelivery.net";
-    private static String IMAGE_VARIANTS_PUBLIC = "public";
+    private static final String IMAGE_BASE_URI = "https://imagedelivery.net";
+    private static final String IMAGE_VARIANTS_PUBLIC = "public";
 
     private final ImageRepository imageRepository;
     private final CloudflareImagesClient client;

--- a/src/main/java/university/likelion/wmt/domain/image/implement/ImageWriter.java
+++ b/src/main/java/university/likelion/wmt/domain/image/implement/ImageWriter.java
@@ -1,0 +1,55 @@
+package university.likelion.wmt.domain.image.implement;
+
+import java.util.Objects;
+
+import jakarta.persistence.EntityNotFoundException;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.image.entity.Image;
+import university.likelion.wmt.domain.image.exception.ImageErrorCode;
+import university.likelion.wmt.domain.image.exception.ImageException;
+import university.likelion.wmt.domain.image.property.ImageProperties;
+import university.likelion.wmt.domain.image.repository.ImageRepository;
+import university.likelion.wmt.domain.image.service.CloudflareImagesClient;
+
+@Component
+@RequiredArgsConstructor
+public class ImageWriter {
+    private static String IMAGE_BASE_URI = "https://imagedelivery.net";
+    private static String IMAGE_VARIANTS_PUBLIC = "public";
+
+    private final ImageRepository imageRepository;
+    private final CloudflareImagesClient client;
+    private final ImageProperties properties;
+
+    public String upload(MultipartFile file) {
+        String cfName = client.upload(file);
+        if (Objects.isNull(cfName)) {
+            throw new ImageException(ImageErrorCode.CLOUDFLARE_IMAGES_UPLOAD_FAILED);
+        }
+
+        Image image = Image.builder()
+            .cfName(cfName)
+            .fileSize(file.getSize())
+            .contentType(file.getContentType())
+            .build();
+        imageRepository.save(image);
+
+        String uri = String.format("%s/%s/%s/%s", IMAGE_BASE_URI, properties.getAccountHash(), cfName,
+            IMAGE_VARIANTS_PUBLIC);
+
+        return uri;
+    }
+
+    public void delete(Long imageId) {
+        Image image = imageRepository.findById(imageId)
+            .orElseThrow(() -> new EntityNotFoundException("image"));
+
+        client.delete(image.getCfName());
+        imageRepository.delete(image);
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/image/property/ImageProperties.java
+++ b/src/main/java/university/likelion/wmt/domain/image/property/ImageProperties.java
@@ -1,0 +1,21 @@
+package university.likelion.wmt.domain.image.property;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.unit.DataSize;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@ConfigurationProperties(prefix = "wmt.cloudflare.images")
+@RequiredArgsConstructor
+@Getter
+public class ImageProperties {
+    private final String email;
+    private final String accountId;
+    private final String accountHash;
+    private final String apikey;
+    private final List<String> allowedMime;
+    private final DataSize sizeLimit;
+}

--- a/src/main/java/university/likelion/wmt/domain/image/repository/ImageRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/image/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package university.likelion.wmt.domain.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import university.likelion.wmt.domain.image.entity.Image;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+}

--- a/src/main/java/university/likelion/wmt/domain/image/service/CloudflareImagesClient.java
+++ b/src/main/java/university/likelion/wmt/domain/image/service/CloudflareImagesClient.java
@@ -1,0 +1,87 @@
+package university.likelion.wmt.domain.image.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import university.likelion.wmt.domain.image.property.ImageProperties;
+
+@Slf4j
+@Component
+public class CloudflareImagesClient {
+    private static final String HTTP_AUTHORIZATION_HEADER_SCHEME_BEARER = "Bearer ";
+    private static final String CLOUDFLARE_IMAGES_API_BASE_URI = "https://api.cloudflare.com/client/v4";
+    private static final String CLOUDFLARE_IMAGES_API_PATH = "/accounts/{accountId}/images/v1";
+
+    private final ImageProperties properties;
+    private final WebClient webClient;
+
+    public CloudflareImagesClient(ImageProperties properties) {
+        this.properties = properties;
+        this.webClient = WebClient.builder()
+            .baseUrl(CLOUDFLARE_IMAGES_API_BASE_URI)
+            .defaultHeader(HttpHeaders.AUTHORIZATION, HTTP_AUTHORIZATION_HEADER_SCHEME_BEARER + properties.getApikey())
+            .build();
+    }
+
+    public String upload(MultipartFile file) {
+        MultipartBodyBuilder builder = new MultipartBodyBuilder();
+        builder.part("file", file.getResource())
+            .filename(Objects.requireNonNull(file.getOriginalFilename()))
+            .contentType(MediaType.parseMediaType(Objects.requireNonNull(file.getContentType())));
+
+        try {
+            CloudflareImagesUploadResponse response = webClient.post()
+                .uri(CLOUDFLARE_IMAGES_API_PATH, properties.getAccountId())
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(builder.build()))
+                .retrieve()
+                .bodyToMono(CloudflareImagesUploadResponse.class)
+                .block();
+
+            return response.result().id();
+        } catch (WebClientException ex) {
+            log.error("업로드를 위해 Cloudflare Images API 서버와 통신 중 오류가 발생했습니다: {}", ex.getMessage());
+        }
+
+        return null;
+    }
+
+    public void delete(String cfName) {
+        try {
+            webClient.delete()
+                .uri(CLOUDFLARE_IMAGES_API_PATH + "/{imageId}", properties.getAccountId(), cfName)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+        } catch (WebClientException ex) {
+            log.error("삭제를 위해 Cloudflare Images API 서버와 통신 중 오류가 발생했습니다: {}", ex.getMessage());
+        }
+    }
+
+    private record CloudflareImagesUploadResponse(
+        List<Object> errors,
+        List<Object> messages,
+        CloudflareImagesUploadResult result,
+        Boolean success
+    ) {
+    }
+
+    private record CloudflareImagesUploadResult(
+        String id,
+        String filename,
+        LocalDateTime uploaded
+    ) {
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/image/service/ImageService.java
+++ b/src/main/java/university/likelion/wmt/domain/image/service/ImageService.java
@@ -6,7 +6,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
-import university.likelion.wmt.domain.dto.response.ImageResponse;
+import university.likelion.wmt.domain.image.dto.response.ImageResponse;
 import university.likelion.wmt.domain.image.implement.ImageValidator;
 import university.likelion.wmt.domain.image.implement.ImageWriter;
 

--- a/src/main/java/university/likelion/wmt/domain/image/service/ImageService.java
+++ b/src/main/java/university/likelion/wmt/domain/image/service/ImageService.java
@@ -1,0 +1,32 @@
+package university.likelion.wmt.domain.image.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.dto.response.ImageResponse;
+import university.likelion.wmt.domain.image.implement.ImageValidator;
+import university.likelion.wmt.domain.image.implement.ImageWriter;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ImageService {
+    private final ImageValidator imageValidator;
+    private final ImageWriter imageWriter;
+
+    @Transactional
+    public ImageResponse upload(MultipartFile file) {
+        imageValidator.validateAllowedMime(file);
+        String uri = imageWriter.upload(file);
+
+        return new ImageResponse(uri);
+    }
+
+    @Transactional
+    public void delete(Long imageId) {
+        imageWriter.delete(imageId);
+    }
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -14,6 +14,7 @@ spring:
       on-profile: local
     import:
       - classpath:/properties/datasource.yaml
+      - classpath:/properties/images.yaml
   # ---- JDBC 데이터베이스 접속 구성
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
@@ -32,6 +33,11 @@ spring:
         hbm2ddl.auto: update
     # 영속성 컨텍스트가 데이터베이스 커넥션을 트랜잭션 종료 즉시 반환합니다.
     open-in-view: false
+  # ---- Spring Data JPA 구성
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
 
 logging:
   level:


### PR DESCRIPTION
## 🚩 작업 요약
**1️⃣ CloudFlare Images API 호출자 및 이미지 도메인 추가**
- CloudFlare Images API 호출을 위한 `CloudflareImagesClient`를 추가합니다
- 이미지 도메인을 추가합니다

## 📋 요구 사항
- 이미지 업로드를 위해 `POST /images/upload` API를 호출하는 것이 아니라 각 도메인에서 `ImageVaildator`와 `ImageWriter`를 사용해야 편할 것 같은데 의견 남겨주세요!
