### PR TITLE
마일리지 도메인 추가

### DIFF
--- a/src/main/java/university/likelion/wmt/common/querydsl/QueryDslConfig.java
+++ b/src/main/java/university/likelion/wmt/common/querydsl/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package university.likelion.wmt.common.querydsl;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/controller/MileageController.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/controller/MileageController.java
@@ -1,0 +1,83 @@
+package university.likelion.wmt.domain.mileage.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.mileage.dto.response.BalanceResponse;
+import university.likelion.wmt.domain.mileage.service.MileageService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mileage")
+public class MileageController {
+    private final MileageService mileageService;
+
+    @GetMapping("/me")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<BalanceResponse> remaining(@AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(mileageService.getBalance(userId));
+    }
+
+    // private final MileageWriter mileageWriter;
+    //
+    // @PostMapping("/earn")
+    // @PreAuthorize("isAuthenticated()")
+    // public ResponseEntity<MileageLogResponse> earn(@Valid @RequestBody EarnRequest req) {
+    //     MileageLog log = mileageWriter.earn(req.userId(), req.amount(), req.expiresAt(),
+    //         MileageLogReferenceType.valueOf(req.refType()), req.refId());
+    //     return ResponseEntity.ok(MileageLogResponse.from(log));
+    // }
+    //
+    // @PostMapping("/use")
+    // @PreAuthorize("isAuthenticated()")
+    // public ResponseEntity<MileageLogResponse> use(@Valid @RequestBody UseRequest req) {
+    //     MileageLog log = mileageWriter.use(req.userId(), req.amount(), MileageLogReferenceType.valueOf(req.refType()),
+    //         req.refId());
+    //     return ResponseEntity.ok(MileageLogResponse.from(log));
+    // }
+    //
+    // public record EarnRequest(
+    //     @NotNull Long userId,
+    //     @NotNull @Positive Long amount,
+    //     LocalDateTime expiresAt,
+    //     String refType,
+    //     Long refId
+    // ) {
+    // }
+    //
+    // public record UseRequest(
+    //     @NotNull Long userId,
+    //     @NotNull @Positive Long amount,
+    //     String refType,
+    //     Long refId
+    // ) {
+    // }
+    //
+    // public record MileageLogResponse(
+    //     Long id,
+    //     Long userId,
+    //     String type,
+    //     Long amount,
+    //     LocalDateTime expiresAt,
+    //     String refType,
+    //     Long refId,
+    //     LocalDateTime createdAt
+    // ) {
+    //     public static MileageLogResponse from(MileageLog log) {
+    //         return new MileageLogResponse(log.getId(),
+    //             log.getUserId(),
+    //             log.getType().name(),
+    //             log.getAmount(),
+    //             log.getExpiresAt(),
+    //             log.getReferenceType().name(),
+    //             log.getReferenceId(),
+    //             log.getCreatedAt());
+    //     }
+    // }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/dto/response/BalanceResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/dto/response/BalanceResponse.java
@@ -1,0 +1,6 @@
+package university.likelion.wmt.domain.mileage.dto.response;
+
+public record BalanceResponse(
+    Long remaining
+) {
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/entity/MileageApply.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/entity/MileageApply.java
@@ -1,0 +1,71 @@
+package university.likelion.wmt.domain.mileage.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+
+@Entity
+@Table(name = "mileage_apply",
+    indexes = {
+        @Index(name = "idx_mileage_apply_src", columnList = "src_log_id"),
+        @Index(name = "idx_mileage_apply_dst", columnList = "dst_log_id")
+    })
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class MileageApply {
+    @Id
+    @Tsid
+    private Long id;
+
+    // 획득, 환불, 운영 상 조정된 마일리지의 원 출처
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "src_log_id", nullable = false)
+    private MileageLog srcLog;
+
+    // 만료, 사용한 마일리지의 출처
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "dst_log_id", nullable = false)
+    private MileageLog dstLog;
+
+    // 마일리지 양
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public MileageApply(MileageLog srcLog, MileageLog dstLog, Long amount) {
+        this.srcLog = srcLog;
+        this.dstLog = dstLog;
+        this.amount = amount;
+    }
+
+    @PrePersist
+    @PreUpdate
+    void validate() {
+        if (amount == null || amount <= 0) {
+            throw new IllegalArgumentException("마일리지 양은 양수여야 합니다.");
+        }
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/entity/MileageLog.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/entity/MileageLog.java
@@ -1,0 +1,113 @@
+package university.likelion.wmt.domain.mileage.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+
+@Table(name = "mileage_logs")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class MileageLog {
+    @Id
+    @Tsid
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 마일리지 기록 유형
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 12)
+    private MileageLogType type;
+
+    // 마일리지의 원래 양
+    @Column(name = "amount", nullable = false)
+    private Long amount;
+
+    // 마일리지의 남은 양
+    @Transient
+    @Setter
+    private Long remaining = 0L;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    // 마일리지 획득, 사용, 환불, 운영 상 조정의 이유를 나타내기 위한 키
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ref_type", nullable = false, length = 32)
+    private MileageLogReferenceType referenceType;
+
+    // 마일리지 획득, 사용, 환불, 운영 상 조정의 이유를 나타내는 연관 키
+    @Column(name = "ref_id", nullable = false)
+    private Long referenceId;
+
+    // 환불, 운영 상 조정 시 조정된 마일리지의 원 출처
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reversal_of")
+    private MileageLog reversalOf;
+
+    @Column(nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Builder
+    public MileageLog(Long userId, MileageLogType type, Long amount, LocalDateTime expiresAt,
+        MileageLogReferenceType referenceType, Long referenceId, MileageLog reversalOf) {
+        this.userId = userId;
+        this.type = type;
+        this.amount = amount;
+        this.expiresAt = expiresAt;
+        this.referenceType = referenceType;
+        this.referenceId = referenceId;
+        this.reversalOf = reversalOf;
+    }
+
+    @PrePersist
+    @PreUpdate
+    void validate() {
+        if (amount == null || amount == 0) {
+            throw new IllegalArgumentException("획득 또는 차감된 마일리지는 0일 수 없습니다.");
+        }
+
+        switch (type) {
+            case EARN, REFUND -> {
+                if (amount <= 0) {
+                    throw new IllegalArgumentException("획득 또는 환불된 마일리지는 양수여야 합니다.");
+                }
+            }
+            case USE, EXPIRE -> {
+                if (amount >= 0) {
+                    throw new IllegalArgumentException("사용 또는 만료된 마일리지는 음수여야 합니다.");
+                }
+                if (expiresAt != null) {
+                    throw new IllegalArgumentException("사용 또는 만료된 마일리지는 만료일을 지정할 수 없습니다.");
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/entity/MileageLogReferenceType.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/entity/MileageLogReferenceType.java
@@ -1,0 +1,6 @@
+package university.likelion.wmt.domain.mileage.entity;
+
+public enum MileageLogReferenceType {
+    MISSION, // 미션
+    ORDER    // 주문
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/entity/MileageLogType.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/entity/MileageLogType.java
@@ -1,0 +1,9 @@
+package university.likelion.wmt.domain.mileage.entity;
+
+public enum MileageLogType {
+    EARN,   // 적립
+    USE,    // 사용
+    EXPIRE, // 만료
+    REFUND, // 환불
+    ADJUST  // 운영 상 조정
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/exception/MileageErrorCode.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/exception/MileageErrorCode.java
@@ -1,0 +1,25 @@
+package university.likelion.wmt.domain.mileage.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+import university.likelion.wmt.common.exception.ErrorCode;
+
+@Getter
+public enum MileageErrorCode implements ErrorCode {
+    USABLE_BALANCE_INSUFFICIENT(HttpStatus.CONFLICT, 47700001, "사용할 수 있는 마일리지가 부족합니다.", null),
+    MONTHLY_EARN_CAP_EXCEEDED(HttpStatus.CONFLICT, 47700002, "한 달에 적립 가능한 마일리지를 초과했습니다.", null);
+
+    private final HttpStatus httpStatus;
+    private final int code;
+    private final String message;
+    private final String documentationUri;
+
+    MileageErrorCode(HttpStatus httpStatus, int code, String message, String documentationUri) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+        this.documentationUri = documentationUri;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/exception/MileageException.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/exception/MileageException.java
@@ -1,0 +1,10 @@
+package university.likelion.wmt.domain.mileage.exception;
+
+import university.likelion.wmt.common.exception.BusinessException;
+import university.likelion.wmt.common.exception.ErrorCode;
+
+public class MileageException extends BusinessException {
+    public MileageException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/implement/MileageReader.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/implement/MileageReader.java
@@ -1,0 +1,21 @@
+package university.likelion.wmt.domain.mileage.implement;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.mileage.repository.MileageLogRepository;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MileageReader {
+    private final MileageLogRepository mileageLogRepository;
+
+    public long getBalance(long userId) {
+        return mileageLogRepository.findUsableMileageByUserIdAndRegDateBefore(userId, LocalDateTime.now());
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/implement/MileageValidator.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/implement/MileageValidator.java
@@ -1,0 +1,46 @@
+package university.likelion.wmt.domain.mileage.implement;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.mileage.exception.MileageErrorCode;
+import university.likelion.wmt.domain.mileage.exception.MileageException;
+import university.likelion.wmt.domain.mileage.repository.MileageApplyRepository;
+import university.likelion.wmt.domain.mileage.repository.MileageLogRepository;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MileageValidator {
+    private static final long MONTHLY_EARN_CAP = 5_000L;
+
+    private final MileageLogRepository mileageLogRepository;
+    private final MileageApplyRepository mileageApplyRepository;
+
+    public void validatePositiveAmount(Long amount) {
+        if (amount <= 0L) {
+            throw new IllegalArgumentException("적립 마일리지는 양수여야 합니다.");
+        }
+    }
+
+    public void validateUsableBalance(Long balance, Long requiredAmount) {
+        if (balance < requiredAmount) {
+            throw new MileageException(MileageErrorCode.USABLE_BALANCE_INSUFFICIENT);
+        }
+    }
+
+    public void validateWithInMonthlyEarnCap(Long userId, Long amount) {
+        LocalDateTime monthStart = LocalDateTime.now().withDayOfMonth(1).toLocalDate().atStartOfDay();
+        LocalDateTime monthEnd = LocalDateTime.now().plusMonths(1).withDayOfMonth(1).toLocalDate().atStartOfDay();
+        long earnedThisMonth = mileageLogRepository.findMileageSumByUserIdAndRegDateBetween(userId, monthStart,
+            monthEnd);
+
+        if (earnedThisMonth + amount > MONTHLY_EARN_CAP) {
+            throw new MileageException(MileageErrorCode.MONTHLY_EARN_CAP_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/implement/MileageWriter.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/implement/MileageWriter.java
@@ -1,0 +1,112 @@
+package university.likelion.wmt.domain.mileage.implement;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.mileage.entity.MileageApply;
+import university.likelion.wmt.domain.mileage.entity.MileageLog;
+import university.likelion.wmt.domain.mileage.entity.MileageLogReferenceType;
+import university.likelion.wmt.domain.mileage.entity.MileageLogType;
+import university.likelion.wmt.domain.mileage.repository.MileageApplyRepository;
+import university.likelion.wmt.domain.mileage.repository.MileageLogRepository;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MileageWriter {
+    private final MileageLogRepository mileageLogRepository;
+    private final MileageApplyRepository mileageApplyRepository;
+    private final MileageValidator mileageValidator;
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Transactional
+    public MileageLog earn(long userId, long amount, LocalDateTime expiresAt, MileageLogReferenceType referenceType,
+        Long referenceId) {
+        // 마일리지 양이 양수인지 확인합니다.
+        mileageValidator.validatePositiveAmount(amount);
+        // 한 달에 획득할 수 있는 마일리지 양을 초과하지 않는지 확인합니다.
+        mileageValidator.validateWithInMonthlyEarnCap(userId, amount);
+
+        MileageLog earnLog = MileageLog.builder()
+            .userId(userId)
+            .type(MileageLogType.EARN)
+            .amount(amount)
+            .expiresAt(expiresAt)
+            .referenceType(referenceType)
+            .referenceId(referenceId)
+            .reversalOf(null)
+            .build();
+        mileageLogRepository.save(earnLog);
+
+        return earnLog;
+    }
+
+    @Transactional
+    public MileageLog use(long userId, long amount, MileageLogReferenceType referenceType, Long referenceId) {
+        // 마일리지 양이 양수인지 확인합니다.
+        mileageValidator.validatePositiveAmount(amount);
+
+        // 사용할 수 있는 마일리지 양 확인합니다.
+        LocalDateTime now = LocalDateTime.now();
+        long usable = mileageLogRepository.findUsableMileageByUserIdAndRegDateBefore(userId, now);
+        mileageValidator.validateUsableBalance(usable, amount);
+
+        // 사용할 수 있는 마일리지 기록 가져옵니다.
+        List<MileageLog> creditLogs = mileageLogRepository.findUsableMileageByUserIdAndAmountOrderByExpiresAtWithPessimisticLock(
+            userId, amount, now);
+        // 마일리지를 사용할 수 있는지 다시 확인합니다.
+        long planned = creditLogs.stream()
+            .mapToLong(log -> log.getRemaining() == null ? 0L : log.getRemaining())
+            .sum();
+        mileageValidator.validateUsableBalance(planned, amount);
+
+        MileageLog useLog = MileageLog.builder()
+            .userId(userId)
+            .type(MileageLogType.USE)
+            .amount(-amount)
+            .expiresAt(null)
+            .referenceType(referenceType)
+            .referenceId(referenceId)
+            .reversalOf(null)
+            .build();
+        mileageLogRepository.save(useLog);
+
+        long remainingNeed = amount;
+        List<MileageApply> applies = new ArrayList<>();
+        for (MileageLog srcCredit : creditLogs) {
+            // 마일리지 상세 기록 등록을 위해 마일리지 기록에서 남은 마일리지 양을 계산합니다.
+            long remainingInLog =
+                srcCredit.getRemaining() == null ? 0L : srcCredit.getRemaining();
+            if (remainingInLog <= 0L) {
+                continue;
+            }
+
+            long piece = Math.min(remainingInLog, remainingNeed);
+            MileageApply apply = MileageApply.builder()
+                .srcLog(em.getReference(MileageLog.class, srcCredit.getId()))
+                .dstLog(useLog)
+                .amount(piece)
+                .build();
+            applies.add(apply);
+
+            remainingNeed -= piece;
+            if (remainingNeed == 0L) {
+                break;
+            }
+        }
+
+        mileageApplyRepository.saveAll(applies);
+        return useLog;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageApplyRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageApplyRepository.java
@@ -1,0 +1,8 @@
+package university.likelion.wmt.domain.mileage.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import university.likelion.wmt.domain.mileage.entity.MileageApply;
+
+public interface MileageApplyRepository extends JpaRepository<MileageApply, Long> {
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageLogRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageLogRepository.java
@@ -1,0 +1,11 @@
+package university.likelion.wmt.domain.mileage.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import university.likelion.wmt.domain.mileage.entity.MileageLog;
+
+public interface MileageLogRepository extends JpaRepository<MileageLog, Long>, MileageLogRepositoryCustom {
+    List<MileageLog> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageLogRepositoryCustom.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageLogRepositoryCustom.java
@@ -1,0 +1,16 @@
+package university.likelion.wmt.domain.mileage.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import university.likelion.wmt.domain.mileage.entity.MileageLog;
+
+public interface MileageLogRepositoryCustom {
+    List<MileageLog> findUsableMileageByUserIdAndAmountOrderByExpiresAtWithPessimisticLock(Long userId,
+        Long needAmount,
+        LocalDateTime now);
+
+    long findMileageSumByUserIdAndRegDateBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    long findUsableMileageByUserIdAndRegDateBefore(Long userId, LocalDateTime now);
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageLogRepositoryImpl.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageLogRepositoryImpl.java
@@ -52,12 +52,11 @@ public class MileageLogRepositoryImpl implements MileageLogRepositoryCustom {
         List<Tuple> rows = queryFactory
             .select(mileageLog, remaining)
             .from(mileageLog)
-            .where(
-                mileageLog.userId.eq(userId)
-                    .and(mileageLog.amount.gt(0L))
-                    .and(mileageLog.type.in(MileageLogType.EARN, MileageLogType.REFUND, MileageLogType.ADJUST))
-                    .and(mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.goe(now)))
-            )
+            .where(mileageLog.userId.eq(userId)
+                .and(mileageLog.amount.gt(0L))
+                .and(mileageLog.type.in(MileageLogType.EARN, MileageLogType.REFUND, MileageLogType.ADJUST))
+                .and(mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.gt(now)))
+                .and(remaining.gt(0L)))
             .orderBy(mileageLog.expiresAt.asc().nullsLast(), mileageLog.id.asc())
             .setLockMode(LockModeType.PESSIMISTIC_WRITE)
             .fetch();
@@ -113,7 +112,7 @@ public class MileageLogRepositoryImpl implements MileageLogRepositoryCustom {
             .where(mileageLog.userId.eq(userId),
                 mileageLog.amount.gt(0L),
                 mileageLog.type.in(MileageLogType.EARN, MileageLogType.REFUND, MileageLogType.ADJUST),
-                mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.goe(now)))
+                mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.gt(now)))
             .fetchOne();
 
         //=> 사용할 수 있는 마일리지를 가진 마일리지 기록에서 이미 사용된 마일리지 양을 계산합니다.
@@ -124,7 +123,7 @@ public class MileageLogRepositoryImpl implements MileageLogRepositoryCustom {
             .where(mileageLog.userId.eq(userId),
                 mileageLog.amount.gt(0L),
                 mileageLog.type.in(MileageLogType.EARN, MileageLogType.REFUND, MileageLogType.ADJUST),
-                mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.goe(now)))
+                mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.gt(now)))
             .fetchOne();
 
         //=> 실제 사용할 수 있는 마일리지 양을 계산합니다.

--- a/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageLogRepositoryImpl.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/repository/MileageLogRepositoryImpl.java
@@ -1,0 +1,136 @@
+package university.likelion.wmt.domain.mileage.repository;
+
+import static university.likelion.wmt.domain.mileage.entity.QMileageApply.*;
+import static university.likelion.wmt.domain.mileage.entity.QMileageLog.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import jakarta.persistence.LockModeType;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.mileage.entity.MileageLog;
+import university.likelion.wmt.domain.mileage.entity.MileageLogType;
+
+@Repository
+@RequiredArgsConstructor
+public class MileageLogRepositoryImpl implements MileageLogRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<MileageLog> findUsableMileageByUserIdAndAmountOrderByExpiresAtWithPessimisticLock(Long userId,
+        Long needAmount,
+        LocalDateTime now) {
+
+        // 필요한 마일리지가 null이거나 0 이하인 경우 사용할 수 있는 마일리지가 없으므로 빈 리스트를 반환합니다.
+        if (needAmount == null || needAmount <= 0L) {
+            return List.of();
+        }
+
+        //=> 단일 획득 마일리지 기록에서 상세 마일리지 사용 기록에 따라 남은 마일리지를 계산합니다.
+        // mileage_log_id와 일치하는 mileage_apply 튜플을 찾아 amount 필드의 값을 모두 더한 후,
+        // mileage_log 튜플의 amount에서 mileage_apply 튜플에서 모두 더한 값을 뺄셈합니다.
+        NumberExpression<Long> remaining = mileageLog.amount.longValue().subtract(JPAExpressions
+            .select(mileageApply.amount.sumLong().coalesce(0L))
+            .from(mileageApply)
+            .where(mileageApply.srcLog.id.eq(mileageLog.id)));
+
+        //=> 마일리지가 존재하는 단일 획득 마일리지 기록을 찾습니다.
+        // 배제 잠금을 실시하여 작업 중 마일리지 적립 또는 사용을 방지합니다.
+        // 남은 마일리지가 있는 만료되지 않은 획득 마일리지 기록 튜플을 찾습니다.
+        // 만료일이 임박한 마일리지부터 사용하기 위해 만료일, ID 순으로 튜플을 정렬합니다.
+        List<Tuple> rows = queryFactory
+            .select(mileageLog, remaining)
+            .from(mileageLog)
+            .where(
+                mileageLog.userId.eq(userId)
+                    .and(mileageLog.amount.gt(0L))
+                    .and(mileageLog.type.in(MileageLogType.EARN, MileageLogType.REFUND, MileageLogType.ADJUST))
+                    .and(mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.goe(now)))
+            )
+            .orderBy(mileageLog.expiresAt.asc().nullsLast(), mileageLog.id.asc())
+            .setLockMode(LockModeType.PESSIMISTIC_WRITE)
+            .fetch();
+
+        long accumulated = 0L;
+        List<MileageLog> picked = new ArrayList<>();
+        for (Tuple tuple : rows) {
+            MileageLog creditLog = tuple.get(mileageLog);
+
+            // 남은 마일리지를 확인합니다.
+            Long remain = Optional.ofNullable(tuple.get(1, Number.class)).map(Number::longValue).orElse(0L);
+            if (remain <= 0L) {
+                continue;
+            }
+
+            // 마일리지가 남아있다면 picked(사용할 수 있는 마일리지 리스트)에 추가합니다.
+            assert creditLog != null;
+            creditLog.setRemaining(remain);
+            picked.add(creditLog);
+            accumulated += remain;
+
+            // 필요한 마일리지에 도달하면 작업을 중단합니다.
+            if (accumulated >= needAmount) {
+                break;
+            }
+        }
+
+        return picked;
+    }
+
+    @Override
+    public long findMileageSumByUserIdAndRegDateBetween(Long userId, LocalDateTime start, LocalDateTime end) {
+        //=> 특정 기간 사이에 획득한 마일리지의 양을 계산합니다.
+        Long sum = queryFactory
+            .select(mileageLog.amount.sumLong())
+            .from(mileageLog)
+            .where(mileageLog.userId.eq(userId)
+                .and(mileageLog.type.eq(MileageLogType.EARN))
+                .and(mileageLog.createdAt.goe(start))
+                .and(mileageLog.createdAt.lt(end))
+            )
+            .fetchOne();
+
+        return sum == null ? 0 : sum;
+    }
+
+    @Override
+    public long findUsableMileageByUserIdAndRegDateBefore(Long userId, LocalDateTime now) {
+        //=> 사용할 수 있는 마일리지의 양을 계산합니다.
+        Long sumCredit = queryFactory
+            .select(mileageLog.amount.sumLong())
+            .from(mileageLog)
+            .where(mileageLog.userId.eq(userId),
+                mileageLog.amount.gt(0L),
+                mileageLog.type.in(MileageLogType.EARN, MileageLogType.REFUND, MileageLogType.ADJUST),
+                mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.goe(now)))
+            .fetchOne();
+
+        //=> 사용할 수 있는 마일리지를 가진 마일리지 기록에서 이미 사용된 마일리지 양을 계산합니다.
+        Long sumApplied = queryFactory
+            .select(mileageApply.amount.sumLong())
+            .from(mileageApply)
+            .join(mileageApply.srcLog, mileageLog)
+            .where(mileageLog.userId.eq(userId),
+                mileageLog.amount.gt(0L),
+                mileageLog.type.in(MileageLogType.EARN, MileageLogType.REFUND, MileageLogType.ADJUST),
+                mileageLog.expiresAt.isNull().or(mileageLog.expiresAt.goe(now)))
+            .fetchOne();
+
+        //=> 실제 사용할 수 있는 마일리지 양을 계산합니다.
+        long credit = sumCredit == null ? 0L : sumCredit;
+        long applied = sumApplied == null ? 0L : sumApplied;
+        long usable = credit - applied;
+        return Math.max(0L, usable);
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mileage/service/MileageService.java
+++ b/src/main/java/university/likelion/wmt/domain/mileage/service/MileageService.java
@@ -1,0 +1,20 @@
+package university.likelion.wmt.domain.mileage.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+import university.likelion.wmt.domain.mileage.dto.response.BalanceResponse;
+import university.likelion.wmt.domain.mileage.implement.MileageReader;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MileageService {
+    private final MileageReader mileageReader;
+
+    public BalanceResponse getBalance(long userId) {
+        return new BalanceResponse(mileageReader.getBalance(userId));
+    }
+}


### PR DESCRIPTION
## 🚩 작업 요약
**1️⃣ 마일리지 도메인 추가**
- 마일리지 기록과 마일리지 상세 기록 엔티티를 추가합니다.
- 마일리지 관련 컨트롤러, 서비스, 리포지토리를 추가합니다.
- 다른 도메인에서 마일리지 도메인을 활용할 수 있는 쓰기, 읽기, 검증 클래스를 추가합니다.

**마일리지 적립 시나리오: 사용자는 미션 수행을 통해 마일리지를 적립한다.**
1. `MileageWriter::earn(사용자 주요 키, 적립 마일리지 양, 마일리지 만료일, 적립 마일리지 출처 유형, 적립 마일리지 출처 주요 키)` 메서드를 호출한다.
2. 해당 메서드는 데이터베이스에 즉시 튜플을 삽입한다.

**마일리지 사용 시나리오: 사용자는 상품권 교환을 통해 마일리지를 사용한다.**
1. `MileageWriter::use(사용자 주요 키, 사용 마일리지 양, 사용 마일리지 출처 유형, 사용 마일리지 출처 주요 키)` 메서드를 호출한다.
2. 해당 메서드는 사용할 수 있는 마일리지 양을 확인하고 mileage_logs 테이블에 즉시 `-사용 마일리지 양`의 튜플을 삽입한다. 또 메서드는 사용한 mileage_apply 테이블에 즉시 `-사용 마일리지 양`의 튜플들을 삽입한다.
  이렇게 함으로써 만료되는 마일리지를 일일이 계산하지 않아도 되며 갱신/삭제가 이루어지지 않고 오직 삽입만 이루어져 투명하게 관리할 수 있습니다.

- **마일리지에 대한 추가 이해가 필요한 경우, [우아한기술블로그](https://techblog.woowahan.com/2587/)를 참조하세요.**

## 📋 요구 사항
- 마일리지 적립 및 사용을 위해 다른 도메인에서 호출이 필요한 경우 Service에서 `MileageWriter`를 활용하면 됩니다.