### PR TITLE
refactor: 미션기능을 위한 이미지 도메인 개선

### DIFF
--- a/src/main/java/university/likelion/wmt/domain/image/entity/Image.java
+++ b/src/main/java/university/likelion/wmt/domain/image/entity/Image.java
@@ -28,7 +28,8 @@ public class Image {
     @Tsid
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 36)
+    //cfName 길이 수정
+    @Column(nullable = false, unique = true, length = 255)
     private String cfName;
 
     @Column(nullable = false)

--- a/src/main/java/university/likelion/wmt/domain/image/implement/ImageWriter.java
+++ b/src/main/java/university/likelion/wmt/domain/image/implement/ImageWriter.java
@@ -52,4 +52,12 @@ public class ImageWriter {
         client.delete(image.getCfName());
         imageRepository.delete(image);
     }
+    // 새롭게 추가된 메서드: cfName을 받아 이미지 URL을 생성하고 반환합니다.
+    public String createImageUrl(String cfName) {
+        return String.format("%s/%s/%s/%s",
+            IMAGE_BASE_URI,
+            properties.getAccountHash(),
+            cfName,
+            IMAGE_VARIANTS_PUBLIC);
+    }
 }

--- a/src/main/java/university/likelion/wmt/domain/image/repository/ImageRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/image/repository/ImageRepository.java
@@ -4,5 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import university.likelion.wmt.domain.image.entity.Image;
 
+import java.util.Optional;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findByCfName(String cfName);
 }


### PR DESCRIPTION
-'Image' entity 클래스에 cfName 길이 255로 변경
-'ImageWriter 클래스에 cfName을 통한 이미지 url을 반환하는 createImageUrl 메서드 추가

