### PR TITLE
feat: 미션 생성 및 인증 기능 추가

### DIFF
--- a/src/main/java/university/likelion/wmt/domain/image/repository/ImageRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/image/repository/ImageRepository.java
@@ -4,5 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import university.likelion.wmt.domain.image.entity.Image;
 
+import java.util.Optional;
+
 public interface ImageRepository extends JpaRepository<Image, Long> {
+    Optional<Image> findByCfName(String cfName);
 }

--- a/src/main/java/university/likelion/wmt/domain/mission/controller/MissionController.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/controller/MissionController.java
@@ -1,0 +1,84 @@
+package university.likelion.wmt.domain.mission.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import university.likelion.wmt.domain.mission.dto.response.MissionResponse;
+import university.likelion.wmt.domain.mission.dto.response.UserProfileResponse;
+import university.likelion.wmt.domain.mission.service.MissionService;
+
+import java.util.List;
+
+@Slf4j // 로깅을 위해 Slf4j 어노테이션 추가
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/missions")
+@PreAuthorize("isAuthenticated()") //미션 컨트롤러 모든 api -> 인증 필요
+public class MissionController {
+    private final MissionService missionService;
+
+    @PostMapping("/start")
+    public ResponseEntity<MissionResponse> startMission(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam("marketId") Long marketId) {
+        log.info("startMission() 메서드 호출, 사용자: {}, 시장 ID: {}", userId, marketId);
+        try {
+            MissionResponse newMission = missionService.startUserExploration(userId,  marketId);
+            log.info("새로운 미션이 성공적으로 생성되었습니다.");
+            return ResponseEntity.ok(newMission);
+        } catch (Exception e) {
+            log.error("미션 생성 중 오류 발생: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(null);
+        }
+    }
+
+    @PostMapping("/end")
+    public ResponseEntity<?> endMission(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam("marketId") Long marketId){
+        long completedMissionCount = missionService.getCompletedMissionCount(userId, marketId);
+        if(completedMissionCount == 0){
+            return ResponseEntity.badRequest().body("미션을 하나도 완료하지 않았습니다.");
+        }
+        missionService.endUserExploration(userId);
+        return ResponseEntity.ok("탐험이 성공적으로 종료되었습니다.");
+    }
+
+    @PostMapping("/authenticate/{missionId}")
+    public ResponseEntity<MissionResponse> authenticateMission(
+        @PathVariable Long missionId,
+        @AuthenticationPrincipal Long userId,
+        @RequestParam("imageFile") MultipartFile imageFile
+    ){
+        MissionResponse response = missionService.authenticateMission(missionId, userId, imageFile);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/refresh")
+    public MissionResponse refreshMission(
+        @AuthenticationPrincipal Long userId,
+        @RequestParam Long marketId) {
+        return missionService.refreshAndGetNewMission(userId, marketId);
+    }
+
+
+    @GetMapping("/profile")
+     public ResponseEntity<UserProfileResponse> getUserProfile(@AuthenticationPrincipal Long userId) {
+         UserProfileResponse userProfile = missionService.getUserProfile(userId);
+       return ResponseEntity.ok(userProfile);
+    }
+
+
+    @GetMapping("/completed/{category}")
+    public ResponseEntity<List<MissionResponse>> getCompletedMissionsByCategory(
+        @AuthenticationPrincipal Long userId,
+        @PathVariable String category
+    ){
+        List<MissionResponse> completedMissions = missionService.getCompletedMissionsByCategory(userId, category);
+        return ResponseEntity.ok(completedMissions);
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/dto/response/CompletedMissionImageResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/dto/response/CompletedMissionImageResponse.java
@@ -1,0 +1,10 @@
+package university.likelion.wmt.domain.mission.dto.response;
+
+import java.time.LocalDateTime;
+
+public record CompletedMissionImageResponse(
+    Long missionId,
+    String cfName,
+    String imageUrl,
+    LocalDateTime completedAt
+) {}

--- a/src/main/java/university/likelion/wmt/domain/mission/dto/response/MissionResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/dto/response/MissionResponse.java
@@ -1,0 +1,35 @@
+package university.likelion.wmt.domain.mission.dto.response;
+
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class MissionResponse {
+    private Long id;
+    private String category;
+    private String content;
+    private String missionTitle;
+    private boolean completed;
+    private LocalDateTime createdAt;
+    private String failureReason;
+
+    public MissionResponse(Long id,
+                           String category,
+                           String content,
+                           String missionTitle,
+                           boolean completed,
+                           LocalDateTime createdAt,
+                           String failureReason) {
+        this.id = id;
+        this.category = category;
+        this.content = content;
+        this.missionTitle = missionTitle;
+        this.completed = completed;
+        this.createdAt = createdAt;
+        this.failureReason = failureReason;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/dto/response/UserProfileResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/dto/response/UserProfileResponse.java
@@ -1,0 +1,14 @@
+package university.likelion.wmt.domain.mission.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfileResponse {
+    private Long userId;
+    private String userType;
+    private MissionResponse currentMission;
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/entity/MasterMission.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/entity/MasterMission.java
@@ -1,0 +1,26 @@
+package university.likelion.wmt.domain.mission.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "master_mission")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MasterMission { //미리 만들어둘 100개의 미션을 저장하는 DB테이블의 설계도
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable  = false)
+    private Long id;
+
+    @Column(name = "missionTitle", nullable = false, length = 20)
+    private String missionTitle;
+
+    @Column(name = "category", nullable = false, length = 20)
+    private String category;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/entity/Mission.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/entity/Mission.java
@@ -1,0 +1,63 @@
+package university.likelion.wmt.domain.mission.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicUpdate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import university.likelion.wmt.domain.image.entity.Image;
+import university.likelion.wmt.domain.market.entity.Market;
+import university.likelion.wmt.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "mission")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@DynamicUpdate
+@EntityListeners(AuditingEntityListener.class)
+public class Mission {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", nullable = false)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, referencedColumnName = "id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "market_id", nullable = false)
+    private Market market;
+
+    @Column(name = "category", nullable = false, length = 20)
+    private String category;
+
+    @Column(name = "missionTitle", nullable = false, length = 20)
+    private String missionTitle;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "completed")
+    private boolean completed = false;
+
+    @Column(name = "created_at", nullable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(name = "report_id")
+    private Long reportId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id" , referencedColumnName = "id")
+    private Image image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "failure_reason_id")
+    private MissionFailureReason failureReason;
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/entity/MissionFailureReason.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/entity/MissionFailureReason.java
@@ -1,0 +1,28 @@
+package university.likelion.wmt.domain.mission.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "failure_reasons")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MissionFailureReason {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String code;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String reason;
+
+    public MissionFailureReason(String code, String reason){
+        this.code = code;
+        this.reason = reason;
+    }
+
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/exception/MissionErrorCode.java
@@ -1,0 +1,24 @@
+package university.likelion.wmt.domain.mission.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MissionErrorCode {
+    //400 Bad Request
+    INVALID_MISSION_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 미션 카테고리입니다."),
+    MISSION_ALREADY_STARTED(HttpStatus.BAD_REQUEST, "이미 진행중인 미션이 있습니다. "),
+    MISSION_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료된 미션입니다."),
+    MISSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "진행 중인 미션을 찾을 수 없습니다."),
+    IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "이미지를 찾을 수 없습니다."), //이미지 예외
+    ALREADY_STARTED_TODAY(HttpStatus.BAD_REQUEST, "탐험은 하루에 한번만 가능합니다."),
+
+    //500 Internal Server Error
+    AI_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "미션 생성에 실패했습니다."),
+    DUPLICATE_MISSION_ID(HttpStatus.INTERNAL_SERVER_ERROR, "중복된 미션 ID가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/exception/MissionException.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/exception/MissionException.java
@@ -1,0 +1,12 @@
+package university.likelion.wmt.domain.mission.exception;
+
+import lombok.Getter;
+
+@Getter
+public class MissionException extends RuntimeException {
+    private final MissionErrorCode errorCode;
+    public MissionException(MissionErrorCode errorCode){
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/respository/MasterMissionRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/respository/MasterMissionRepository.java
@@ -1,0 +1,16 @@
+package university.likelion.wmt.domain.mission.respository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import university.likelion.wmt.domain.mission.entity.MasterMission;
+
+import java.util.List;
+
+@Repository
+public interface MasterMissionRepository extends JpaRepository<MasterMission, Long> {
+    @Query(value = "SELECT * FROM master_mission ORDER BY RAND() LIMIT :count",
+        nativeQuery = true) //무작위로 섞기
+    List<MasterMission> findRandomMissions(@Param("count") int count);
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/respository/MissionFailureReasonRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/respository/MissionFailureReasonRepository.java
@@ -1,0 +1,10 @@
+package university.likelion.wmt.domain.mission.respository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import university.likelion.wmt.domain.mission.entity.MissionFailureReason;
+
+import java.util.Optional;
+
+public interface MissionFailureReasonRepository extends JpaRepository<MissionFailureReason, Long> {
+    Optional<MissionFailureReason> findByCode(String code);
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/respository/MissionRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/respository/MissionRepository.java
@@ -1,0 +1,45 @@
+package university.likelion.wmt.domain.mission.respository;
+
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import university.likelion.wmt.domain.market.entity.Market;
+import university.likelion.wmt.domain.mission.entity.Mission;
+import university.likelion.wmt.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+    // 특정 유저의 모든 미션을 삭제
+    void deleteAllByUser(User user);
+    // 특정 유저의 완료되지 않은 미션 개수를 반환
+    long countByUserAndCompletedFalse(User user);
+    // 특정 유저의 완료되지 않은 미션 중 가장 첫 번째 미션을 반환
+    Optional<Mission> findFirstByUserAndCompletedFalseOrderByCreatedAtAsc(User user);
+    // 특정 유저의 완료된 모든 미션 목록을 반환
+
+    @EntityGraph(attributePaths = "image")
+    List<Mission> findByUserAndCompletedTrue(User user);
+    // 특정 유저의 완료되지 않은 미션만 삭제
+    void deleteByUserAndCompletedFalse(User user);
+    // 특정 유저의 완료된 미션을 카테고리별로 찾아 반환
+    List<Mission> findByUserAndCategoryAndCompletedTrue(User user, String category);
+
+    @Query("SELECT COUNT(m) FROM Mission m WHERE m.user = :user AND m.market = :market AND m.completed = true")
+    long countByUserAndCompletedTrue(@Param("user") User user, @Param("market") Market market);
+
+    //특정 유저의 가장 먼저 생성된 미션의 생성 시간을 반환
+    Optional<LocalDateTime> findFirstByUserOrderByCreatedAtAsc(User user);
+
+    List<Mission> findByReportId(Long reportId);
+
+    List<Mission> findByMarketId(Long marketId);
+
+    @EntityGraph(attributePaths = "image")
+    Optional<Mission> findByUserAndImageCfName(User user, String cfName);
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/service/MissionGeminiService.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/service/MissionGeminiService.java
@@ -1,0 +1,75 @@
+package university.likelion.wmt.domain.mission.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import university.likelion.wmt.domain.mission.util.MissionPromptBuilder;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+
+@Slf4j
+@Service
+public class MissionGeminiService {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    @Value("${gemini.api.key}")
+    private String apiKey;
+
+    //미션 메서드만 남기기 - 미션 생성 메서드 삭제
+    public String authenticateMission(String missionContent, String category, MultipartFile imageFile) {
+        try {
+            byte[] imageBytes = imageFile.getBytes(); //-> 이미지 바이트 배열로 변환
+            String base64Image = Base64.getEncoder().encodeToString(imageBytes); //Base64 문자열로 인코딩
+
+            String prompt = MissionPromptBuilder.buildAuthenticationPrompt(missionContent, category);
+            String geminiApiUrl = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=" + apiKey;
+            String payload = objectMapper.writeValueAsString(
+                new Object() {
+                    public final Object[] contents = new Object[]{
+                        new Object() {
+                            public final String role = "user";
+                            public final Object[] parts = new Object[]{
+                                new Object() {
+                                    public final String text = prompt;
+                                },
+                                new Object() {
+                                    public final Object inlineData = new Object() {
+                                        public final String mimeType = imageFile.getContentType();
+                                        public final String data = base64Image;
+                                    };
+                                }
+                            };
+                        }
+                    };
+                }
+            );
+            HttpRequest request = HttpRequest.newBuilder()
+                .uri(new URI(geminiApiUrl))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(payload))
+                .build();
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                log.error("Gemini Vision API 호출에 실패. Status: {}, Body: {}", response.statusCode(), response.body());
+                return "ERROR";
+            }
+            JsonNode rootNode = objectMapper.readTree(response.body());
+            String responseText = rootNode.path("candidates").path(0).path("content").path("parts").path(0).path("text").asText();
+
+            return responseText.trim().toUpperCase();
+
+        } catch (Exception e) {
+            log.error("Gemini API를 이용한 미션 인증 중 오류 발생: {}", e.getMessage());
+            return "ERROR";
+        }
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/service/MissionService.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/service/MissionService.java
@@ -1,0 +1,300 @@
+package university.likelion.wmt.domain.mission.service;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import university.likelion.wmt.domain.image.entity.Image;
+import university.likelion.wmt.domain.image.implement.ImageValidator;
+import university.likelion.wmt.domain.image.implement.ImageWriter;
+import university.likelion.wmt.domain.image.repository.ImageRepository;
+import university.likelion.wmt.domain.market.entity.Market;
+import university.likelion.wmt.domain.market.exception.MarketErrorCode;
+import university.likelion.wmt.domain.market.exception.MarketException;
+import university.likelion.wmt.domain.market.repository.MarketRepository;
+import university.likelion.wmt.domain.mileage.entity.MileageLogReferenceType;
+import university.likelion.wmt.domain.mileage.implement.MileageWriter;
+import university.likelion.wmt.domain.mission.dto.response.MissionResponse;
+import university.likelion.wmt.domain.mission.dto.response.UserProfileResponse;
+import university.likelion.wmt.domain.mission.entity.MasterMission;
+import university.likelion.wmt.domain.mission.entity.Mission;
+import university.likelion.wmt.domain.mission.entity.MissionFailureReason;
+import university.likelion.wmt.domain.mission.exception.MissionErrorCode;
+import university.likelion.wmt.domain.mission.exception.MissionException;
+import university.likelion.wmt.domain.mission.respository.MasterMissionRepository;
+import university.likelion.wmt.domain.mission.respository.MissionFailureReasonRepository;
+import university.likelion.wmt.domain.mission.respository.MissionRepository;
+import university.likelion.wmt.domain.mission.util.MissionPromptBuilder;
+import university.likelion.wmt.domain.user.entity.User;
+import university.likelion.wmt.domain.user.exception.UserErrorCode;
+import university.likelion.wmt.domain.user.exception.UserException;
+import university.likelion.wmt.domain.user.repository.UserRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+    private final MissionRepository missionRepository;
+    private final MasterMissionRepository masterMissionRepository;
+    private final UserRepository userRepository;
+    private final ImageValidator imageValidator;
+    private final ImageWriter imageWriter;
+    private final ImageRepository imageRepository;
+    private final MissionGeminiService missionGeminiService;
+    private final MileageWriter mileageWriter;
+    private final MarketRepository marketRepository;
+    private final MissionFailureReasonRepository missionFailureReasonRepository;
+
+    @Value("${hackathon.mode.start-date}")
+    private String hackathonStartDate;
+
+    @Value("${hackathon.mode.end-date}")
+    private String hackathonEndDate;
+
+    @PostConstruct
+    public void init() {
+        List<MissionFailureReason> reasons = missionFailureReasonRepository.findAll();
+        MissionPromptBuilder.setFailureReasons(reasons);
+    }
+
+    private User findUserById(Long userId){
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    // 해커톤 기간인지 확인하는 헬퍼 메서드
+    private boolean isDuringHackathon(){
+        LocalDate today = LocalDate.now();
+        LocalDate start = LocalDate.parse(hackathonStartDate);
+        LocalDate end = LocalDate.parse(hackathonEndDate);
+        // 종료일을 포함하도록 isAfter 대신 !isAfter를 사용
+        return !today.isBefore(start) && !today.isAfter(end);
+    }
+
+    @Transactional
+    public MissionResponse authenticateMission(Long missionId, Long userId, MultipartFile imageFile) {
+        User user = findUserById(userId);
+        Mission mission = missionRepository.findById(missionId)
+            .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+        if (!mission.getUser().getId().equals(user.getId())) {
+            throw new MissionException(MissionErrorCode.MISSION_NOT_FOUND);
+        }
+        imageValidator.validateAllowedMime(imageFile);
+        String imageUrl = imageWriter.upload(imageFile);
+        log.info("업로드 된 이미지 URL: {}", imageUrl);
+        String cfName = parseImageIdFromUrl(imageUrl);
+        log.info("추출된 cfName: {}", cfName);
+        Optional<Image> imageOpt = imageRepository.findByCfName(cfName);
+        if (imageOpt.isEmpty()) {
+            log.error("Image not found for cfName: {}", cfName);
+            throw new MissionException(MissionErrorCode.MISSION_NOT_FOUND);
+        }
+        Image image = imageOpt.get();
+
+        String geminiResponse = missionGeminiService.authenticateMission(
+            mission.getContent(),
+            mission.getCategory(),
+            imageFile
+        );
+        if("ERROR".equals(geminiResponse)){
+            throw new MissionException(MissionErrorCode.AI_GENERATION_FAILED);
+        }
+        boolean isSuccess = geminiResponse.startsWith("YES");
+
+        mission.setCompleted(isSuccess);
+        mission.setImage(image);
+
+        if(!isSuccess){
+            String failureCode = geminiResponse.substring(geminiResponse.indexOf(":")+1);
+            MissionFailureReason failureReason = missionFailureReasonRepository.findByCode(failureCode)
+                .orElse(null);
+            mission.setFailureReason(failureReason);
+        }
+        missionRepository.save(mission);
+
+        //미션 완료 시 마일리지 UP (※임시 설정 * 100 포인트)
+        if(isSuccess) {
+            long earnedPoints = 100L;
+            mileageWriter.earn(user.getId(), earnedPoints, LocalDateTime.now().plusYears(1), MileageLogReferenceType.MISSION, mission.getId());
+            log.info("마일리지 적립 완료. 사용자 ID: {}", user.getId());
+        }
+
+        Optional<Mission> next = missionRepository.findFirstByUserAndCompletedFalseOrderByCreatedAtAsc(user);
+
+        long remainingMissions = missionRepository.countByUserAndCompletedFalse(user);
+        if (remainingMissions < 5) {
+            log.info("미션 재고가 부족합니다 ({}개 남음). 새 미션 10개를 생성합니다.", remainingMissions);
+            List<MasterMission> masterMissions = getRandomMasterMissions(10);
+            masterMissions.forEach(mm -> {
+                Mission newMission = Mission.builder()
+                    .user(user)
+                    .category(mm.getCategory())
+                    .content(mm.getContent())
+                    .completed(false)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+                missionRepository.save(newMission);
+            });
+        }
+
+        if (next.isEmpty()) {
+            Optional<Mission> newNext = missionRepository.findFirstByUserAndCompletedFalseOrderByCreatedAtAsc(user);
+            return toResponse(newNext.orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND)));
+        }
+        return toResponse(mission);
+    }
+
+    private String parseImageIdFromUrl(String imageUrl) {
+        String urlWithoutVariant = imageUrl.substring(0, imageUrl.lastIndexOf('/'));
+        String cfName = urlWithoutVariant.substring(urlWithoutVariant.lastIndexOf('/') + 1);
+        return cfName;
+    }
+    @Transactional
+    public MissionResponse startUserExploration(Long userId, Long marketId) {
+        log.info("미션 일괄 생성 시작. (사용자: {}, 시장: {}, 개수: {})", userId, marketId, 10);
+        User user = findUserById(userId);
+
+        if (!isDuringHackathon()) {
+            LocalDate today = LocalDate.now();
+            if (user.getLastExplorationStartDate() != null && user.getLastExplorationStartDate().isEqual(today)) {
+                throw new MissionException(MissionErrorCode.ALREADY_STARTED_TODAY);
+            }
+        }
+        user.setLastExplorationStartDate(LocalDate.now());
+        userRepository.save(user);
+
+        missionRepository.deleteByUserAndCompletedFalse(user);
+        List<MasterMission> masterMissions = getRandomMasterMissions(10);
+
+        Market market = marketRepository.findById(marketId)
+                .orElseThrow(() -> new MarketException(MarketErrorCode.MARKET_NOT_FOUND));
+
+        masterMissions.forEach(mm -> {
+            Mission newMission = Mission.builder()
+                .user(user)
+                .market(market)
+                .category(mm.getCategory())
+                .content(mm.getContent())
+                .missionTitle(mm.getMissionTitle())
+                .completed(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+            missionRepository.save(newMission);
+        });
+        Mission firstMission = missionRepository.findFirstByUserAndCompletedFalseOrderByCreatedAtAsc(user)
+            .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+        return toResponse(firstMission);
+    }
+
+    @Transactional
+    public MissionResponse refreshAndGetNewMission(Long userId, Long marketId) {
+        log.info("미션 새로고침 요청. (사용자: {})", userId);
+        User user = findUserById(userId);
+        missionRepository.deleteByUserAndCompletedFalse(user);
+        List<MasterMission> masterMissions = getRandomMasterMissions(10);
+
+        Market market = marketRepository.findById(marketId)
+                .orElseThrow(() -> new MarketException(MarketErrorCode.MARKET_NOT_FOUND));
+
+        masterMissions.forEach(mm -> {
+            Mission newMission = Mission.builder()
+                .user(user)
+                .market(market)
+                .category(mm.getCategory())
+                .content(mm.getContent())
+                .missionTitle(mm.getMissionTitle())
+                .completed(false)
+                .createdAt(LocalDateTime.now())
+                .build();
+            missionRepository.save(newMission);
+        });
+        Mission firstMission = missionRepository.findFirstByUserAndCompletedFalseOrderByCreatedAtAsc(user)
+            .orElseThrow(() -> new MissionException(MissionErrorCode.MISSION_NOT_FOUND));
+        return toResponse(firstMission);
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = findUserById(userId);
+        String userType = determineUserType(user);
+        Optional<Mission> currentMission = missionRepository.findFirstByUserAndCompletedFalseOrderByCreatedAtAsc(user);
+        MissionResponse missionResponse = currentMission.map(this::toResponse).orElse(null);
+        return new UserProfileResponse(userId, userType, missionResponse);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MissionResponse> getCompletedMissionsByCategory(Long userId, String category) {
+        User user = findUserById(userId);
+        List<Mission> completedMissions = missionRepository.findByUserAndCategoryAndCompletedTrue(user, category);
+        return completedMissions.stream()
+            .map(this::toResponse)
+            .collect(Collectors.toList());
+    }
+
+    private String determineUserType(User user) {
+        Map<String, Long> categoryCounts = missionRepository.findByUserAndCompletedTrue(user).stream()
+            .collect(Collectors.groupingBy(Mission::getCategory, Collectors.counting()));
+        return categoryCounts.entrySet().stream()
+            .max(Comparator.comparingLong(Map.Entry::getValue))
+            .map(Map.Entry::getKey)
+            .orElse("입문자");
+    }
+
+    private List<MasterMission> getRandomMasterMissions(int count) {
+        long totalMissions = masterMissionRepository.count();
+        if (totalMissions < count) {
+            throw new MissionException(MissionErrorCode.MISSION_NOT_FOUND);
+        }
+        return masterMissionRepository.findRandomMissions(count);
+    }
+
+    @Transactional
+    public void endUserExploration(Long userId){
+        log.info("사용자 탐험 종료 처리. 사용자: {}", userId);
+        User user = findUserById(userId);
+        missionRepository.deleteByUserAndCompletedFalse(user);
+    }
+
+    @Transactional(readOnly = true)
+    public long getCompletedMissionCount(Long userId, Long marketId) {
+        User user = findUserById(userId);
+        Market market = marketRepository.findById(marketId)
+            .orElseThrow(() -> new MarketException(MarketErrorCode.MARKET_NOT_FOUND));
+
+        return missionRepository.countByUserAndCompletedTrue(user, market);
+    }
+    @Transactional(readOnly = true)
+    public List<MissionResponse> getMissionsByMarket(Long marketId) {
+        List<Mission> missions = missionRepository.findByMarketId(marketId);
+        return missions.stream()
+            .map(this::toResponse)
+            .collect(Collectors.toList());
+    }
+
+    private MissionResponse toResponse(Mission mission) {
+        if (mission == null) {
+            throw new MissionException(MissionErrorCode.MISSION_NOT_FOUND);
+        }
+        String failureReason = mission.getFailureReason() != null ? mission.getFailureReason().getReason() : null;
+        return new MissionResponse(
+            mission.getId(),
+            mission.getCategory(),
+            mission.getContent(),
+            mission.getMissionTitle(),
+            mission.isCompleted(),
+            mission.getCreatedAt(),
+            failureReason
+        );
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/mission/util/MissionPromptBuilder.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/util/MissionPromptBuilder.java
@@ -1,0 +1,33 @@
+package university.likelion.wmt.domain.mission.util;
+
+import university.likelion.wmt.domain.mission.entity.MissionFailureReason;
+
+import java.util.List;
+
+public class MissionPromptBuilder {
+    private static List<MissionFailureReason> failureReasons;
+    public static void setFailureReasons(List<MissionFailureReason> reasons) {
+        MissionPromptBuilder.failureReasons = reasons;
+    }
+    public static String buildAuthenticationPrompt(String missionContent, String category){
+        StringBuilder failureReasonList = new StringBuilder();
+        if(failureReasons != null){
+            for (MissionFailureReason reason : failureReasons) {
+                failureReasonList.append(String.format("- %s: %s\n", reason.getCode(), reason.getReason()));
+            }
+            }
+
+        String basePrompt = String.format("제공된 사진이 다음 미션 '%s'를 수행한 사진입니까? " +
+            "사진이 미션 내용과 일치하면 'YES'를, 아니면 'NO'를 출력해주세요. " +
+            "만약 사진이 미션과 불일치한다면, 다음 5가지 실패 사유 중 가장 적합한 사유 코드를 선택하여 'NO:실패코드' 형식으로 응답하세요.\n\n" +
+            "실패 사유 목록:\n%s\n" +
+            "예시) NO:SHAKY_PHOTO", missionContent, failureReasonList.toString());
+
+        return switch(category.toLowerCase()) {
+            case "감성형" -> basePrompt + " 사진에서 '추억', '오래된', '정겨운' 등의 감성적 키워드가 연상되는지 중점적으로 판단하세요.";
+            case "모험형" -> basePrompt + " 사진이 '길', '간판', '건물' 등 시장의 특정 장소를 탐색한 증거를 보여주는지 판단하세요.";
+            case "먹보형" -> basePrompt + " 사진에 '음식'이나 '요리', '식당'과 같은 먹는 행위와 관련된 요소가 포함되어 있는지 판단하세요.";
+            default -> basePrompt;
+        };
+    }
+}


### PR DESCRIPTION
- 'Mission' entity 클래스
- 'MasterMission' entity  클래스 : 미션 템플릿 저장하는 클래스
- 'MissionFailureReason' 클래스 : 미션 실패 사유 및 코드 제공

#AI 기능
-'MissionGeminiService' 클래스 : GeminiApi 호출 및 인증 메서드 추가, 실패 사유 제공 기능 추가 -'MissionService' 클래스 : 미션 생성, 새로고침, 인증, 종료, 조회 메서드 추가

#Prompt
-'MissionPromptBuilder' : 미션 인증을 요청하는 프롬프트와 미션 실패 시 어떤 사유를 제공할지 요청하는 프롬프트 존재

