### PR TITLE
feat: report 도메인에 사용자 속성 부여하는 기능 추가

### DIFF
--- a/src/main/java/university/likelion/wmt/domain/report/dto/response/ReportResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/report/dto/response/ReportResponse.java
@@ -14,5 +14,6 @@ public record ReportResponse(
     Long earnedMileage,
     Long remainingMonthlyMileage,
     String reportTitle,
-    String journalContent
+    String journalContent,
+    String userType
 ) {}

--- a/src/main/java/university/likelion/wmt/domain/report/service/ReportService.java
+++ b/src/main/java/university/likelion/wmt/domain/report/service/ReportService.java
@@ -191,6 +191,14 @@ public class ReportService {
         log.info("조회된 완료 미션 이미지 수: {}", images.size());
         return images;
     }
+    private String determineUserType(User user) {
+        Map<String, Long> categoryCounts = missionRepository.findByUserAndCompletedTrue(user).stream()
+            .collect(Collectors.groupingBy(Mission::getCategory, Collectors.counting()));
+        return categoryCounts.entrySet().stream()
+            .max(Comparator.comparingLong(Map.Entry::getValue))
+            .map(Map.Entry::getKey)
+            .orElse("입문자");
+    }
 
     @Transactional(readOnly = true)
     public List<ReportResponse> getMyReports(Long userId) {
@@ -225,6 +233,8 @@ public class ReportService {
             throw new RuntimeException("JSON 문자열을 미션 카테고리 맵으로 변환하는 중 오류가 발생했습니다.", e);
         }
 
+        String userType = determineUserType(report.getUser());
+
         return new ReportResponse(
             report.getId(),
             report.getExplorationDate(),
@@ -235,7 +245,8 @@ public class ReportService {
             earnedMileage,
             remainingMonthlyMileage,
             report.getReportTitle(),
-            report.getJournalContent()
+            report.getJournalContent(),
+            userType
         );
     }
 


### PR DESCRIPTION
- ReportResponse : String userType 반환 추가
- ReportService : 속성 부여하는 기능인 determineUserType 메서드 추가

## ⭐️ 관련 이슈
리포트 생성 시 반환 할 때 사용자의 속성타입이 존재 하지 않음

**1️⃣ 구현한 내용1**
-ReportService 클래스에 유저의 타입을 정해주는 determineUserType 추가했습니다. (MissionService에 존재하는 determineUserType 메서드와 동일)

**2️⃣ 구현한 내용2**
-Report 생성 시 유저 타입 반환할 수 있도록 String userType 추가했습니다.


