### PR TITLE
상품 ID 반환 시 문자열로 반환토록 수정

### DIFF
--- a/src/main/java/university/likelion/wmt/domain/shop/dto/response/MerchandiseResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/shop/dto/response/MerchandiseResponse.java
@@ -4,13 +4,13 @@ import university.likelion.wmt.domain.shop.entity.Merchandise;
 import university.likelion.wmt.domain.shop.entity.MerchandiseType;
 
 public record MerchandiseResponse(
-    Long id,
+    String id,
     String name,
     Long price,
     MerchandiseType type
 ) {
     public static MerchandiseResponse from(Merchandise merchandise) {
-        return new MerchandiseResponse(merchandise.getId(), merchandise.getName(), merchandise.getPrice(),
+        return new MerchandiseResponse(merchandise.getId().toString(), merchandise.getName(), merchandise.getPrice(),
             merchandise.getType());
     }
 }


### PR DESCRIPTION
## ⭐️ 관련 이슈
closed #30 

## 🚩 작업 요약
**1️⃣ 상품 목록 반환 시 ID를 정수가 아닌 문자열로 반환하도록 수정**
- Number에 저장 시 상품권 ID가 손상돼 잘못된 ID가 저장되는 문제를 수정합니다.
- 상품권 ID를 구성하는 long의 범위는 -9,223,372,036,854,775,808 ~ 9,223,372,036,854,775,807이지만 자바스크립트 Number의 안전 범위는 -9,007,199,254,740,991 ~ 9,007,199,254,740,991이기에 ID가 손상됩니다.