### PR TITLE
modify: 탐험 하나도 안했을 시 탐험종료 부정

### DIFF
--- a/src/main/java/university/likelion/wmt/domain/mission/exception/MissionErrorCode.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/exception/MissionErrorCode.java
@@ -14,6 +14,7 @@ public enum MissionErrorCode {
     MISSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "진행 중인 미션을 찾을 수 없습니다."),
     IMAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "이미지를 찾을 수 없습니다."), //이미지 예외
     ALREADY_STARTED_TODAY(HttpStatus.BAD_REQUEST, "탐험은 하루에 한번만 가능합니다."),
+    MISSION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "미션을 하나라도 수행해야합니다."),
 
     //500 Internal Server Error
     AI_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "미션 생성에 실패했습니다."),

--- a/src/main/java/university/likelion/wmt/domain/mission/service/MissionService.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/service/MissionService.java
@@ -295,6 +295,12 @@ public class MissionService {
     public void endUserExploration(Long userId) {
         log.info("사용자 탐험 종료 처리. 사용자: {}", userId);
         User user = findUserById(userId);
+        long completedMissionCount = missionRepository.countByUserAndCompletedTrue(user);
+
+        if(completedMissionCount == 0){
+            log.warn("미션 수행을 하나도 하지 않았습니다. userId = {}", userId);
+            throw new MissionException(MissionErrorCode.MISSION_NOT_COMPLETED);
+        }
         missionRepository.deleteByUserAndCompletedFalse(user);
     }
 


### PR DESCRIPTION
## ⭐️ 관련 이슈
미션을 수행하지 않고 탐험을 종료했을 시 넘어가는 오류 발생

**1️⃣ 구현한 내용1**
MissionService endUserExploration 메서드에 Exception 추가


