### PR TITLE
전체 미션 개수를 가져와 오늘 탐험이 비정상 종료되는 문제 수정

### DIFF
--- a/src/main/java/university/likelion/wmt/domain/mission/controller/MissionController.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/controller/MissionController.java
@@ -1,17 +1,25 @@
 package university.likelion.wmt.domain.mission.controller;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import university.likelion.wmt.domain.mission.dto.response.MissionResponse;
 import university.likelion.wmt.domain.mission.dto.response.UserProfileResponse;
 import university.likelion.wmt.domain.mission.service.MissionService;
-
-import java.util.List;
 
 @Slf4j // 로깅을 위해 Slf4j 어노테이션 추가
 @RestController
@@ -39,12 +47,13 @@ public class MissionController {
     @PostMapping("/end")
     public ResponseEntity<?> endMission(
         @AuthenticationPrincipal Long userId,
-        @RequestParam("marketId") Long marketId){
+        @RequestParam("marketId") Long marketId,
+        @RequestParam("startsAt") LocalDateTime startsAt){
         long completedMissionCount = missionService.getCompletedMissionCount(userId, marketId);
         if(completedMissionCount == 0){
             return ResponseEntity.badRequest().body("미션을 하나도 완료하지 않았습니다.");
         }
-        missionService.endUserExploration(userId);
+        missionService.endUserExploration(userId, startsAt);
         return ResponseEntity.ok("탐험이 성공적으로 종료되었습니다.");
     }
 

--- a/src/main/java/university/likelion/wmt/domain/mission/respository/MissionRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/respository/MissionRepository.java
@@ -40,6 +40,9 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     @Query("SELECT COUNT(m) FROM Mission m WHERE m.user = :user AND m.completed = true")
     long countByUserAndCompletedTrue(@Param("user") User user);
 
+    @Query("SELECT COUNT(m) FROM Mission m WHERE m.user = :user AND m.completed = true AND m.createdAt > :createdAt")
+    long countByUserAndCompletedTrueAndCreatedAtGreaterThanEqual(@Param("user") User user, LocalDateTime createdAt);
+
     @Query("SELECT COUNT(m) FROM Mission m WHERE m.user = :user AND m.market = :market AND m.completed = true")
     long countByUserAndCompletedTrue(@Param("user") User user, @Param("market") Market market);
 

--- a/src/main/java/university/likelion/wmt/domain/mission/service/MissionService.java
+++ b/src/main/java/university/likelion/wmt/domain/mission/service/MissionService.java
@@ -292,10 +292,11 @@ public class MissionService {
     }
 
     @Transactional
-    public void endUserExploration(Long userId) {
+    public void endUserExploration(Long userId, LocalDateTime startsAt) {
         log.info("사용자 탐험 종료 처리. 사용자: {}", userId);
         User user = findUserById(userId);
-        long completedMissionCount = missionRepository.countByUserAndCompletedTrue(user);
+        long completedMissionCount = missionRepository.countByUserAndCompletedTrueAndCreatedAtGreaterThanEqual(user, startsAt);
+        log.info("현재 수행한 미션의 개수는 {}개입니다.", completedMissionCount);
 
         if(completedMissionCount == 0){
             log.warn("미션 수행을 하나도 하지 않았습니다. userId = {}", userId);

--- a/src/main/java/university/likelion/wmt/domain/report/service/ReportService.java
+++ b/src/main/java/university/likelion/wmt/domain/report/service/ReportService.java
@@ -60,6 +60,7 @@ public class ReportService {
             });
 
         List<Mission> completedMissions = missionRepository.findByUserAndCompletedTrueAndReportIdNull(user);
+        log.info("{}", completedMissions);
         if (completedMissions.isEmpty()) {
             log.warn("완료된 미션이 없습니다. userId: {}", userId);
             throw new MissionException(MissionErrorCode.MISSION_NOT_FOUND);


### PR DESCRIPTION
## 🚩 작업 요약
**1️⃣ 전체 미션 개수를 가져와 오늘 탐험이 비정상 종료되는 문제 수정**
- 전체 미션 개수가 아닌 미션 시작일 이후 미션 개수로 계산하여 아무 것도 수행하지 않은채로 종료되는 문제를 수정합니다.
