### PR TITLE
🦁 계정 관련 API 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-undertow'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.apache.tika:tika-core:3.2.1'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -42,9 +43,10 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
-    // Spring Data JPA, QueryDSL
+    // Spring Data JPA/Redis, QueryDSL
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.hypersistence:hypersistence-utils-hibernate-63:3.10.1'
     implementation 'io.github.openfeign.querydsl:querydsl-core:6.12'
     implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.12'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,3 +17,14 @@ services:
       - ./docker-infra/mariadb/conf.d:/etc/mysql/conf.d
       - ./docker-infra/mariadb/data:/var/lib/mysql
       - ./docker-infra/mariadb/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+
+  redis:
+    image: redis:alpine
+    container_name: wmt-redis
+    ports:
+      - "6379:6379"
+    environment:
+      TZ: Asia/Seoul
+    labels:
+      - "name=redis"
+      - "mode=standalone"

--- a/src/main/java/university/likelion/wmt/common/auth/AuthConfig.java
+++ b/src/main/java/university/likelion/wmt/common/auth/AuthConfig.java
@@ -32,6 +32,8 @@ public class AuthConfig {
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
+    public static final String[] ACCEPTED_URL_LIST = {"/", "/users/sign-up", "/users/sign-in", "/users/sign-out", "/users/refresh"};
+
     @Bean
     public SecurityFilterChain authSecurityFilterChain(HttpSecurity http) throws Exception {
         return http
@@ -51,7 +53,7 @@ public class AuthConfig {
             .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
             .authorizeHttpRequests(req -> req
-                .requestMatchers("/", "/users/sign-up", "/users/sign-in").permitAll()
+                .requestMatchers(ACCEPTED_URL_LIST).permitAll()
                 .anyRequest().authenticated())
 
             .exceptionHandling(ex -> ex

--- a/src/main/java/university/likelion/wmt/common/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/university/likelion/wmt/common/auth/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package university.likelion.wmt.common.auth;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
 
@@ -35,7 +36,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return request.getHeader(HttpHeaders.AUTHORIZATION) == null;
+        return request.getHeader(HttpHeaders.AUTHORIZATION) == null
+            || Arrays.stream(AuthConfig.ACCEPTED_URL_LIST).anyMatch(s -> s.equals(request.getRequestURI()));
     }
 
     @Override

--- a/src/main/java/university/likelion/wmt/common/auth/JwtProperties.java
+++ b/src/main/java/university/likelion/wmt/common/auth/JwtProperties.java
@@ -1,0 +1,15 @@
+package university.likelion.wmt.common.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "wmt.jwt")
+public class JwtProperties {
+    private final String secretKey;
+    private final long accessTokenSeconds;
+    private final long refreshTokenSeconds;
+}

--- a/src/main/java/university/likelion/wmt/common/auth/Tokens.java
+++ b/src/main/java/university/likelion/wmt/common/auth/Tokens.java
@@ -1,0 +1,9 @@
+package university.likelion.wmt.common.auth;
+
+public record Tokens(
+    String accessToken,
+    Long accessTokenExpiresIn,
+    String refreshToken,
+    Long refreshTokenExpiresIn
+) {
+}

--- a/src/main/java/university/likelion/wmt/common/redis/RedisConfig.java
+++ b/src/main/java/university/likelion/wmt/common/redis/RedisConfig.java
@@ -1,0 +1,32 @@
+package university.likelion.wmt.common.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    private final String redisHost;
+    private final int redisPort;
+
+    public RedisConfig(@Value("${spring.data.redis.host}") final String redisHost,
+        @Value("${spring.data.redis.port}") final int redisPort) {
+        this.redisHost = redisHost;
+        this.redisPort = redisPort;
+    }
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(){
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/user/controller/AuthController.java
+++ b/src/main/java/university/likelion/wmt/domain/user/controller/AuthController.java
@@ -12,7 +12,9 @@ import org.springframework.web.bind.annotation.RestController;
 import lombok.RequiredArgsConstructor;
 
 import university.likelion.wmt.domain.user.dto.request.SignInRequest;
+import university.likelion.wmt.domain.user.dto.request.SignOutRequest;
 import university.likelion.wmt.domain.user.dto.request.SignUpRequest;
+import university.likelion.wmt.domain.user.dto.request.TokenRefreshRequest;
 import university.likelion.wmt.domain.user.dto.response.TokenResponse;
 import university.likelion.wmt.domain.user.service.AuthService;
 
@@ -31,6 +33,18 @@ public class AuthController {
     @PostMapping("/sign-in")
     public ResponseEntity<TokenResponse> signIn(@Valid @RequestBody SignInRequest signInRequest) {
         TokenResponse tokenResponse = authService.signIn(signInRequest);
+        return ResponseEntity.ok(tokenResponse);
+    }
+
+    @PostMapping("/sign-out")
+    public ResponseEntity<TokenResponse> signOut(@Valid @RequestBody SignOutRequest signOutRequest) {
+        authService.signOut(signOutRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@Valid @RequestBody TokenRefreshRequest tokenRefreshRequest) {
+        TokenResponse tokenResponse = authService.refresh(tokenRefreshRequest);
         return ResponseEntity.ok(tokenResponse);
     }
 }

--- a/src/main/java/university/likelion/wmt/domain/user/dto/request/SignOutRequest.java
+++ b/src/main/java/university/likelion/wmt/domain/user/dto/request/SignOutRequest.java
@@ -1,0 +1,7 @@
+package university.likelion.wmt.domain.user.dto.request;
+
+public record SignOutRequest(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/src/main/java/university/likelion/wmt/domain/user/dto/request/TokenRefreshRequest.java
+++ b/src/main/java/university/likelion/wmt/domain/user/dto/request/TokenRefreshRequest.java
@@ -1,0 +1,7 @@
+package university.likelion.wmt.domain.user.dto.request;
+
+public record TokenRefreshRequest(
+    String accessToken,
+    String refreshToken
+) {
+}

--- a/src/main/java/university/likelion/wmt/domain/user/dto/response/TokenResponse.java
+++ b/src/main/java/university/likelion/wmt/domain/user/dto/response/TokenResponse.java
@@ -2,10 +2,12 @@ package university.likelion.wmt.domain.user.dto.response;
 
 public record TokenResponse(
     String accessToken,
+    String refreshToken,
     String tokenType,
-    long expiresIn
+    long accessTokenExpiresIn,
+    long refreshTokenExpiresIn
 ) {
-    public TokenResponse(String accessToken) {
-        this(accessToken, "Bearer", 1209600L);
+    public TokenResponse(String accessToken, long accessTokenExpiresIn, String refreshToken, long refreshTokenExpiresIn) {
+        this(accessToken, refreshToken, "Bearer", accessTokenExpiresIn, refreshTokenExpiresIn);
     }
 }

--- a/src/main/java/university/likelion/wmt/domain/user/repository/RedisRefreshTokenRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/user/repository/RedisRefreshTokenRepository.java
@@ -1,0 +1,95 @@
+package university.likelion.wmt.domain.user.repository;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import university.likelion.wmt.common.auth.JwtProperties;
+
+@Repository
+public class RedisRefreshTokenRepository implements RefreshTokenRepository {
+    private static final String KEY_PREFIX = "auth:refresh";
+    private static final String INDEX_PREFIX = "auth:uid";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ValueOperations<String, String> valueOperations;
+    private final SetOperations<String, String> setOperations;
+
+    private final JwtProperties jwtProperties;
+
+    public RedisRefreshTokenRepository(RedisTemplate<String, String> redisTemplate, JwtProperties jwtProperties) {
+        this.redisTemplate = redisTemplate;
+        this.valueOperations = redisTemplate.opsForValue();
+        this.setOperations = redisTemplate.opsForSet();
+
+        this.jwtProperties = jwtProperties;
+    }
+
+    @Override
+    public void save(final Long userId, final String refreshToken) {
+        String tokenKey = getTokenKey(refreshToken);
+        String indexKey = getIndexKey(userId);
+
+        redisTemplate.executePipelined((RedisCallback<?>) connection -> {
+            valueOperations.set(tokenKey, userId.toString(), Duration.ofSeconds(jwtProperties.getRefreshTokenSeconds()));
+            setOperations.add(indexKey, tokenKey);
+
+            return null;
+        });
+    }
+
+    @Override
+    public Optional<Long> findByRefreshToken(String refreshToken) {
+        String tokenKey = getTokenKey(refreshToken);
+
+        String memberId = valueOperations.get(tokenKey);
+        if (Objects.isNull(memberId)) {
+            return Optional.empty();
+        }
+        return Optional.of(Long.parseLong(memberId));
+    }
+
+    @Override
+    public void delete(Long userId, String refreshToken) {
+        String tokenKey = getTokenKey(refreshToken);
+        String indexKey = getIndexKey(userId);
+
+        redisTemplate.executePipelined((RedisCallback<?>) connection -> {
+            setOperations.remove(indexKey, tokenKey);
+            redisTemplate.delete(tokenKey);
+
+            Long remaining = setOperations.size(indexKey);
+            if (remaining != null && remaining == 0L) {
+                redisTemplate.delete(indexKey);
+            }
+
+            return null;
+        });
+    }
+
+    @Override
+    public void deleteAllByUserId(Long userId) {
+        String indexKey = getIndexKey(userId);
+
+        Set<String> tokens = setOperations.members(indexKey);
+        if (tokens != null && !tokens.isEmpty()) {
+            redisTemplate.delete(tokens);
+        }
+        redisTemplate.delete(indexKey);
+    }
+
+    private String getTokenKey(final String refreshToken) {
+        return KEY_PREFIX + ":" + refreshToken;
+    }
+
+    private String getIndexKey(final Long userId) {
+        return INDEX_PREFIX + ":" + userId;
+    }
+}

--- a/src/main/java/university/likelion/wmt/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/university/likelion/wmt/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package university.likelion.wmt.domain.user.repository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+    void save(Long userId, String refreshToken);
+
+    Optional<Long> findByRefreshToken(String refreshToken);
+
+    void delete(Long userId, String refreshToken);
+
+    void deleteAllByUserId(Long userId);
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -40,7 +40,17 @@ spring:
         hbm2ddl.auto: update
     # 영속성 컨텍스트가 데이터베이스 커넥션을 트랜잭션 종료 즉시 반환합니다.
     open-in-view: false
-  # ---- Spring Data JPA 구성
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
+    # ---- Spring Data Redis 구성
+    redis:
+      host: ${wmt.redis.host}
+      port: ${wmt.redis.port}
+      repositories:
+        enabled: false
+  # ---- Multipart 업로드 구성
   servlet:
     multipart:
       max-file-size: 30MB

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -40,7 +40,17 @@ spring:
         hbm2ddl.auto: update
     # 영속성 컨텍스트가 데이터베이스 커넥션을 트랜잭션 종료 즉시 반환합니다.
     open-in-view: false
-  # ---- Spring Data JPA 구성
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
+  # ---- Spring Data Redis 구성
+    redis:
+      host: ${wmt.redis.host}
+      port: ${wmt.redis.port}
+      repositories:
+        enabled: false
+  # ---- Multipart 업로드 구성
   servlet:
     multipart:
       max-file-size: 30MB

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -15,10 +15,19 @@ spring:
         default_batch_fetch_size: 100
         hbm2ddl.auto: create-drop
     open-in-view: false
+  data:
+    web:
+      pageable:
+        one-indexed-parameters: true
+    redis:
+      host: localhost
+      port: 6379
+      repositories:
+        enabled: false
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 10MB
+      max-file-size: 30MB
+      max-request-size: 30MB
 
 wmt:
   mission:


### PR DESCRIPTION
## 🚩 작업 요약
**1️⃣ JWT RTR 방식으로 변경**
- 액세스 토큰의 유효 기간을 10분, 리프레시 토큰의 유효 기간을 2주로 설정합니다.
- 액세스 토큰 만료 시 토큰 재발급 API를 호출해야 하며 재발급 시 액세스 토큰 및 리프레시 토큰이 재발급됩니다.

**2️⃣ 계정 관련 API 추가**
- 로그아웃, 토큰 재발급 API를 추가합니다.